### PR TITLE
lua52, install lua.hpp

### DIFF
--- a/luajit/CMakeLists.txt
+++ b/luajit/CMakeLists.txt
@@ -69,7 +69,7 @@ INCLUDE(CheckTypeSize)
 
 # LuaJIT specific
 option ( LUAJIT_DISABLE_FFI "Disable FFI." OFF )
-option ( LUAJIT_ENABLE_LUA52COMPAT "Enable Lua 5.2 compatibility." OFF )
+option ( LUAJIT_ENABLE_LUA52COMPAT "Enable Lua 5.2 compatibility." ON )
 option ( LUAJIT_DISABLE_JIT "Disable JIT." OFF )
 option ( LUAJIT_CPU_SSE2 "Use SSE2 instead of x87 instructions." ON )
 option ( LUAJIT_CPU_NOCMOV "Disable NOCMOV." OFF )
@@ -135,6 +135,7 @@ endif ()
 
 ## SOURCES
 INSTALL(FILES src/luaconf.h src/lua.h src/lauxlib.h src/lualib.h
+              src/lua.hpp src/luajit.h
   DESTINATION "${INSTALL_INCLUDE_SUBDIR}")
 
 MACRO(LJ_TEST_ARCH stuff)


### PR DESCRIPTION
Install lua.hpp (used for C++ code that uses luajit) and luajit.h (included by lua.hpp)

Also, enable 5.2 compatibility for good things like non-braindead xpcall.

See https://github.com/torch/torch7/pull/54 which modifies torch7 to work with 5.2 compatibility.
