### PR TITLE
Increased the DEFAULT_GRANULARITY to  512MB.

### DIFF
--- a/luajit/src/lj_alloc.c
+++ b/luajit/src/lj_alloc.c
@@ -37,7 +37,7 @@
 #define MAX_SIZE_T		(~(size_t)0)
 #define MALLOC_ALIGNMENT	((size_t)8U)
 
-#define DEFAULT_GRANULARITY	((size_t)128U * (size_t)1024U)
+#define DEFAULT_GRANULARITY	((size_t)512U * (size_t)1024U * (size_t)1024U)
 #define DEFAULT_TRIM_THRESHOLD	((size_t)2U * (size_t)1024U * (size_t)1024U)
 #define DEFAULT_MMAP_THRESHOLD	((size_t)128U * (size_t)1024U)
 #define MAX_RELEASE_CHECK_RATE	255


### PR DESCRIPTION
On Mac, luajit often runs out of memory. The error is: 

    luajit: not enough memory

The cause:
Luajit is able to use only the first 2GB of memory.
Luajit is using the memory to hold tables, references and strings.
Tensors are not restricted to 2GB of memory.
But a tensor can stole a memory from the first 2GB.
This happens on Mac. On a Mac, the first available memory is given to the tensor.

I implemented the DEFAULT_GRANULARITY change mentioned at:
http://comments.gmane.org/gmane.comp.lang.lua.luajit/3288

The memory assigned to tensors is now above the first 512MB.
You can reproduce the out-of-memory problem by:

    local ffi = require("ffi")

    ffi.cdef[[
    void *malloc(size_t size);
    void free(void *ptr);
    ]]

    local N = 2^31
    local array = ffi.cast("char *", ffi.C.malloc(N))
    assert(array ~= nil, "out of memory")

    local address = ffi.cast("long", array)
    print(string.format("got address: %s MB", address / (1024 * 1024)))
    if address > 2^31 then
        ffi.C.free(array)
        print("got memory above 2GB")
        return
    end

    -- If holding the array, the following loop
    -- will run quickly out of memory.
    local holder = {}
    for i = 1, math.huge do
        local msg = tostring(i) .. '\n'
        table.insert(holder, msg)
        if i % 1000000 == 0 then
            io.stderr:write(msg)
        end
    end

    ffi.C.free(array)
