### PR TITLE
BUGFIX Deprecated rocks repository

### DIFF
--- a/luarocks/lfw/luarocks_config.lua
+++ b/luarocks/lfw/luarocks_config.lua
@@ -1,7 +1,7 @@
 local LFW_ROOT = config.LFW_ROOT
 rocks_servers = {
    [[https://raw.githubusercontent.com/torch/rocks/master]],
-   [[https://raw.githubusercontent.com/torch/luarocks-mirror/master/rocks]]
+   [[http://luarocks.org/repositories/rocks]]
 }
 rocks_trees = {
    { root = LFW_ROOT, rocks_dir = LFW_ROOT..[[\rocks]],


### PR DESCRIPTION
Updated with official updated rock repository. The previous one was breaking code by installing deprecated packages.
