### PR TITLE
moving github luarocks mirror to the more up-to-date moonrocks one

### DIFF
--- a/luarocks/install.bat
+++ b/luarocks/install.bat
@@ -583,7 +583,7 @@ if not exists(vars.CONFIG_FILE) then
 	f:write([=[
 rocks_servers = {
    [[https://raw.githubusercontent.com/torch/rocks/master]],
-   [[https://raw.githubusercontent.com/torch/luarocks-mirror/master/rocks]]
+   [[https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master]]
 }
 rocks_trees = {
 ]=])

--- a/luarocks/lfw/luarocks_config.lua
+++ b/luarocks/lfw/luarocks_config.lua
@@ -1,7 +1,7 @@
 local LFW_ROOT = config.LFW_ROOT
 rocks_servers = {
    [[https://raw.githubusercontent.com/torch/rocks/master]],
-   [[https://raw.githubusercontent.com/torch/luarocks-mirror/master/rocks]]
+   [[https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master]]
 }
 rocks_trees = {
    { root = LFW_ROOT, rocks_dir = LFW_ROOT..[[\rocks]],

--- a/luarocks/src/luarocks/cfg.lua
+++ b/luarocks/src/luarocks/cfg.lua
@@ -196,7 +196,7 @@ local defaults = {
    rocks_servers = {
       {
         "https://raw.githubusercontent.com/torch/rocks/master",
-        "https://raw.githubusercontent.com/torch/luarocks-mirror/master/rocks/"
+        "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master"
       }
    },
 

--- a/luarocks/src/luarocks/config.lua.in
+++ b/luarocks/src/luarocks/config.lua.in
@@ -13,5 +13,5 @@ rocks_trees = {
 
 rocks_servers = {
    [[https://raw.githubusercontent.com/torch/rocks/master]],
-   [[https://raw.githubusercontent.com/torch/luarocks-mirror/master/rocks]]
+   [[https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master]]
 }

--- a/luarocks/src/luarocks/config.lua.win.in
+++ b/luarocks/src/luarocks/config.lua.win.in
@@ -13,7 +13,7 @@ rocks_trees = {
 
 rocks_servers = {
    [[https://raw.githubusercontent.com/torch/rocks/master]],
-   [[https://raw.githubusercontent.com/torch/luarocks-mirror/master/rocks]]
+   [[https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master]]
 }
 
 variables = {


### PR DESCRIPTION
@atcold pointed out that luarocks.org now uses rocks.moonscript.org as their official rock repo (probably because they were so unreliable!!!). The moonscript guys keep an official (uptodate) github mirror of their moonrocks, so moving our default luarocks.org mirror to that.
