### PR TITLE
Add rule for static version of libluajit-2.1

### DIFF
--- a/luajit-2.1/CMakeLists.txt
+++ b/luajit-2.1/CMakeLists.txt
@@ -369,8 +369,12 @@ include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR} dynasm src)
 
 IF(WITH_AMALG)
   add_library(libluajit SHARED src/ljamalg.c ${DEPS} )
+  add_library(luajit-static STATIC src/ljamalg.c ${DEPS} )
+  set_property(TARGET luajit-static PROPERTY POSITION_INDEPENDENT_CODE 1)
 ELSE()
   add_library(libluajit SHARED ${SRC_LJCORE} ${DEPS} )
+  add_library(luajit-static STATIC ${SRC_LJCORE} ${DEPS} )
+  set_property(TARGET luajit-static PROPERTY POSITION_INDEPENDENT_CODE 1)
 ENDIF()
 
 target_link_libraries (libluajit ${LIBS} )


### PR DESCRIPTION
This also builds libluajit-static.a.
Tested locally, the static library links properly thanks to the fPIC property.